### PR TITLE
Modernise docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
-version: '3.8'
-
 services:
-
   pd0:
     container_name: surrealdb-pd0
-    image: pingcap/pd:v6.1.0
+    hostname: pd0
+    image: pingcap/pd:v8.5.0
     ports:
       - "2379"
     volumes:
@@ -20,10 +18,16 @@ services:
       - --data-dir=/data/pd0
       - --log-file=/logs/pd0.log
     restart: on-failure
+    healthcheck:
+      test: /pd-ctl health | jq -e ".[] | select(.name == \"$(hostname)\").health"
+      start_period: 5s
+      retries: 5
+      timeout: 10s
 
   pd1:
     container_name: surrealdb-pd1
-    image: pingcap/pd:v6.1.0
+    hostname: pd1
+    image: pingcap/pd:v8.5.0
     ports:
       - "2379"
     volumes:
@@ -39,10 +43,16 @@ services:
       - --data-dir=/data/pd1
       - --log-file=/logs/pd1.log
     restart: on-failure
+    healthcheck:
+      test: /pd-ctl health | jq -e ".[] | select(.name == \"$(hostname)\").health"
+      start_period: 5s
+      retries: 5
+      timeout: 10s
 
   pd2:
     container_name: surrealdb-pd2
-    image: pingcap/pd:v6.1.0
+    hostname: pd2
+    image: pingcap/pd:v8.5.0
     ports:
       - "2379"
     volumes:
@@ -58,10 +68,16 @@ services:
       - --data-dir=/data/pd2
       - --log-file=/logs/pd2.log
     restart: on-failure
+    healthcheck:
+      test: /pd-ctl health | jq -e ".[] | select(.name == \"$(hostname)\").health"
+      start_period: 5s
+      retries: 5
+      timeout: 10s
 
   tikv0:
     container_name: surrealdb-tikv0
-    image: pingcap/tikv:v6.1.0
+    hostname: tikv0
+    image: pingcap/tikv:v8.5.0
     volumes:
       - ./data:/data
       - ./logs:/logs
@@ -72,14 +88,23 @@ services:
       - --pd=pd0:2379,pd1:2379,pd2:2379
       - --log-file=/logs/tikv0.log
     depends_on:
-      - "pd0"
-      - "pd1"
-      - "pd2"
+      pd0:
+        condition: service_healthy
+      pd1:
+        condition: service_healthy
+      pd2:
+        condition: service_healthy
     restart: on-failure
+    healthcheck:
+      test: /tikv-ctl --host $(hostname):20160 metrics
+      start_period: 5s
+      retries: 5
+      timeout: 10s
 
   tikv1:
     container_name: surrealdb-tikv1
-    image: pingcap/tikv:v6.1.0
+    hostname: tikv1
+    image: pingcap/tikv:v8.5.0
     volumes:
       - ./data:/data
       - ./logs:/logs
@@ -90,14 +115,23 @@ services:
       - --pd=pd0:2379,pd1:2379,pd2:2379
       - --log-file=/logs/tikv1.log
     depends_on:
-      - "pd0"
-      - "pd1"
-      - "pd2"
+      pd0:
+        condition: service_healthy
+      pd1:
+        condition: service_healthy
+      pd2:
+        condition: service_healthy
     restart: on-failure
+    healthcheck:
+      test: /tikv-ctl --host $(hostname):20160 metrics
+      start_period: 5s
+      retries: 5
+      timeout: 10s
 
   tikv2:
     container_name: surrealdb-tikv2
-    image: pingcap/tikv:v6.1.0
+    hostname: tikv2
+    image: pingcap/tikv:v8.5.0
     volumes:
       - ./data:/data
       - ./logs:/logs
@@ -108,14 +142,22 @@ services:
       - --pd=pd0:2379,pd1:2379,pd2:2379
       - --log-file=/logs/tikv2.log
     depends_on:
-      - "pd0"
-      - "pd1"
-      - "pd2"
+      pd0:
+        condition: service_healthy
+      pd1:
+        condition: service_healthy
+      pd2:
+        condition: service_healthy
     restart: on-failure
+    healthcheck:
+      test: /tikv-ctl --host $(hostname):20160 metrics
+      start_period: 5s
+      retries: 5
+      timeout: 10s
 
   prometheus:
     container_name: surrealdb-prometheus
-    image: prom/prometheus:v2.2.1
+    image: prom/prometheus:v3.1.0
     user: root
     command:
       - --log.level=error
@@ -134,7 +176,7 @@ services:
       - monitoring
 
   grafana:
-    image: grafana/grafana:6.0.1
+    image: grafana/grafana:11.4.0
     container_name: surrealdb-grafana
     user: "0"
     environment:
@@ -156,14 +198,17 @@ services:
     container_name: surrealdb
     ports:
       - "8000:8000"
-    command: 
+    command:
       - start
       - --log=trace
       - --user=root
       - --pass=root
       - tikv://pd0:2379
     depends_on:
-      - tikv0
-      - tikv1
-      - tikv2
+      tikv0:
+        condition: service_healthy
+      tikv1:
+        condition: service_healthy
+      tikv2:
+        condition: service_healthy
     restart: always


### PR DESCRIPTION
This PR aims to modernise the Docker Compose template by addressing the following issues noted during testing:

## 1. Container version
  - `pd`/`tikv` being out-of-date in the 6.1.x branch (latest at the time of writing is 6.1.7).
  - `grafana` being 5 major releases out-of-date.
  - `prom/prometheus:v2.2.1` is deprecated (see `stdout` below)
```
╰─❯ docker run --rm prom/prometheus:v2.2.1
Unable to find image 'prom/prometheus:v2.2.1' locally
v2.2.1: Pulling from prom/prometheus
docker: [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/prom/prometheus:v2.2.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/.
See 'docker run --help'.
```

With `pd` and `tikv` introducing no breaking changes when switching from 6.x to 8.x, I opted to bump the major version. `grafana` being barebone config means breaking changes are irrelevant to us. `prometheus` is simply pinning to `latest`'s equivalent. Local integration testing only used https://github.com/surrealdb/surrealdb/blob/7798a801f0cbaaab65de49071a6a8458cf78e3ab/crates/sdk/tests/create.rs#L13-L18 as a smoke test. 

## 2. Container spin-up order and monitoring
Currently, the `docker-compose.yml` is shotgun spinning up containers without `healthcheck`s. This PR adds `healthcheck`s to containers to:

1. Enforce spin-up order: PD -> TiKV -> SurrealDB.
2. Reduce noise from SurrealDB restarting due to TiKV cluster not ready (and TiKV restarting due to PD not ready).
3. Give decent at-a-glance info on whether a container is behaving.
    - An edge case is the TiKV containers' check. `/tikv-ctl --host $(hostname):20160 metrics` merely dumps out all metrics. Determining which metric is relevant is beyond my abilities.

To simplify the `healthcheck`s, `hostname`s are added to the containers for differentiation (PD containers) and sanity (TiKV containers) purposes.

